### PR TITLE
Fix the spelling of receive

### DIFF
--- a/Sources/BluetoothLinux/HCI/DevicePollEvent.swift
+++ b/Sources/BluetoothLinux/HCI/DevicePollEvent.swift
@@ -12,7 +12,7 @@ import SystemPackage
 
 public extension HostController {
     
-    func recieve<Event>(_ eventType: Event.Type) async throws -> Event where Event: HCIEventParameter, Event.HCIEventType == HCIGeneralEvent {
+    func receive<Event>(_ eventType: Event.Type) async throws -> Event where Event: HCIEventParameter, Event.HCIEventType == HCIGeneralEvent {
         var newFilter = HCISocketOption.Filter()
         newFilter.setPacketType(.event)
         newFilter.setEvent(Event.event)

--- a/Sources/BluetoothLinux/L2CAP/L2CAPSocket.swift
+++ b/Sources/BluetoothLinux/L2CAP/L2CAPSocket.swift
@@ -189,7 +189,7 @@ public struct L2CAPSocket: Bluetooth.L2CAPSocket {
     }
     
     /// Reads from the socket.
-    public func recieve(_ bufferSize: Int) async throws -> Data {
+    public func receive(_ bufferSize: Int) async throws -> Data {
         return try await socket.read(bufferSize)
     }
     

--- a/Sources/BluetoothLinux/SocketOption.swift
+++ b/Sources/BluetoothLinux/SocketOption.swift
@@ -35,8 +35,8 @@ public enum BluetoothSocketOption: CInt, SocketOptionID {
     /// Bluetooth Socket Send MTU
     case sendMTU        = 12 // BT_SNDMTU
     
-    /// Bluetooth Socket Recieve MTU
-    case recieveMTU     = 13 // BT_RCVMTU
+    /// Bluetooth Socket Receive MTU
+    case receiveMTU     = 13 // BT_RCVMTU
     
     /// Bluetooth Phy
     case phy            = 14 // BT_PHY


### PR DESCRIPTION
**What does this PR Do?**

“Receive" was spelled incorrectly throughout this whole project, just make sure it compiles. This can’t be merged until [this](https://github.com/PureSwift/Bluetooth/pull/153) is and the commit hash in the swift package file will need to be updated

**Sweet giphy showing how you feel about this PR**

![Giphy](https://media.giphy.com/media/rkDXJA9GoWR2/giphy.gif)
