### PR TITLE
Add padding for Linux kernel 6.8+ compatibility

### DIFF
--- a/Sources/BluetoothLinux/Internal/CInterop.swift
+++ b/Sources/BluetoothLinux/Internal/CInterop.swift
@@ -571,6 +571,10 @@ public extension CInterop {
         
         public var opcode: UInt16 = 0
         
+        // Explicit padding for Linux kernel 6.8+ compatibility
+        // The kernel expects 16 bytes but the struct is naturally 14 bytes
+        private var _padding: UInt16 = 0
+        
         public init() { }
     }
 }


### PR DESCRIPTION
**Fix**

Add padding for Linux kernel 6.8+ compatibility

**Summary**

Adds explicit padding to ensure struct alignment compatibility with Linux kernel 6.8+.

**Problem**

The struct was naturally 14 bytes but Linux kernel 6.8+ expects 16 bytes, causing potential alignment issues and compatibility problems.

**Solution**

- Added explicit _padding field (UInt16) to CInterop.swift:576
- Ensures the struct meets the 16-byte size requirement expected by newer kernel versions
- Maintains backward compatibility with older kernel versions
